### PR TITLE
Adds minor fixes and optional acme config

### DIFF
--- a/deployment/geonode/Chart.yaml
+++ b/deployment/geonode/Chart.yaml
@@ -7,11 +7,11 @@ sources:
 - https://github.com/zalf-rdm/geonode-k8s
 dependencies:
   - name: postgres-operator-ui
-    version: ~1.10.0
+    version: ~1.9.0
     repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui/
     condition: postgres-operator-ui.enabled
   - name: postgres-operator
-    version: ~1.10.0
+    version: ~1.9.0
     repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator/
     condition: postgres-operator.enabled
   - name: rabbitmq

--- a/deployment/geonode/Chart.yaml
+++ b/deployment/geonode/Chart.yaml
@@ -6,19 +6,19 @@ home: https://github.com/zalf-rdm/geonode-k8s
 sources:
 - https://github.com/zalf-rdm/geonode-k8s
 dependencies:
-- name: postgres-operator-ui
-  version: 1.9.0
-  repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui/
-  condition: postgres-operator-ui.enabled
-- name: postgres-operator
-  version: 1.9.0
-  repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator/
-  condition: postgres-operator.enabled
-- name: rabbitmq
-  version: ~10.1.7
-  repository: https://charts.bitnami.com/bitnami
-  condition: rabbitmq.enabled
-- name: memcached
-  repository: https://charts.bitnami.com/bitnami
-  condition: geonode.memcached.enaled
-  version: ~6.x.x
+  - name: postgres-operator-ui
+    version: ~1.10.0
+    repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui/
+    condition: postgres-operator-ui.enabled
+  - name: postgres-operator
+    version: ~1.10.0
+    repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator/
+    condition: postgres-operator.enabled
+  - name: rabbitmq
+    version: ~10.1.7
+    repository: https://charts.bitnami.com/bitnami
+    condition: rabbitmq.enabled
+  - name: memcached
+    repository: https://charts.bitnami.com/bitnami
+    condition: geonode.memcached.enaled
+    version: ~6.x.x

--- a/deployment/geonode/README.md
+++ b/deployment/geonode/README.md
@@ -16,13 +16,16 @@ Helm Chart for Geonode
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | memcached | ~6.x.x |
 | https://charts.bitnami.com/bitnami | rabbitmq | ~10.1.7 |
-| https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui/ | postgres-operator-ui | 1.9.0 |
-| https://opensource.zalando.com/postgres-operator/charts/postgres-operator/ | postgres-operator | 1.9.0 |
+| https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui/ | postgres-operator-ui | ~1.9.0 |
+| https://opensource.zalando.com/postgres-operator/charts/postgres-operator/ | postgres-operator | ~1.9.0 |
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| geonode.acme.email | string | `"support@example.com"` | the email to be used to gain certificates |
+| geonode.acme.enabled | bool | `false` | enables cert-manager to do ACME challenges (aka certificates via letsencrypt) |
+| geonode.acme.stageUrl | string | `"https://acme-staging-v02.api.letsencrypt.org/directory"` | ACME staging environment (use acme-staging to avoid running into rate limits) stageUrl: https://acme-v02.api.letsencrypt.org/directory |
 | geonode.celery.container_name | string | `"celery"` |  |
 | geonode.celery.resources.limits.cpu | int | `1` | limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | geonode.celery.resources.limits.memory | string | `"1Gi"` | limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -61,7 +64,7 @@ Helm Chart for Geonode
 | geonode.ingress.externalPort | int | `80` | external ingress port |
 | geonode.ingress.externalScheme | string | `"http"` | external ingress schema. if set to https ingress tls is used. Loading tls certificate via tls-secret options Available options: (http|https) |
 | geonode.ingress.ingressClassName | string | `nil` | define kubernetes ingress class for geonode ingress |
-| geonode.ingress.tlsSecret | string | `"geonode-tls-secret"` | tls certificate for geonode ingress https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/. is used when geonode.ingress.externalScheme is set to https |
+| geonode.ingress.tlsSecret | string | `"geonode-tls-secret"` | tls certificate for geonode ingress https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/ (for the use of cert-manager, configure the acme section properly). is used when geonode.ingress.externalScheme is set to https |
 | geonode.ldap.always_update_user | bool | `true` | always update local user database from ldap |
 | geonode.ldap.attr_map_email_addr | string | `"mailPrimaryAddress"` | email attribute used from ldap  |
 | geonode.ldap.attr_map_first_name | string | `"givenName"` | given name attribute used from ldap |
@@ -161,8 +164,7 @@ Helm Chart for Geonode
 | nginx.resources.requests.cpu | string | `"500m"` | requested cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | nginx.resources.requests.memory | string | `"1Gi"` | requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | postgres-operator-ui | object | `{"enabled":false,"envs":{"operatorApiUrl":"http://{{ $.Release.Name }}-postgres-operator:8080"},"ingress":{"enabled":false,"hosts":[{"host":"postgres-ui","paths":[""]}],"ingressClassName":null},"replicaCount":1,"service":{"port":80,"type":"ClusterIP"}}` | VALUES DEFINITION: https://github.com/zalando/postgres-operator/blob/master/charts/postgres-operator-ui/values.yaml |
-| postgres-operator.api_port | int | `8080` | REST API listener listens to this port |
-| postgres-operator.configLoggingRestApi | string | `nil` |  |
+| postgres-operator.configLoggingRestApi.api_port | int | `8080` | REST API listener listens to this port |
 | postgres-operator.enabled | bool | `true` | enable postgres-operator (this or postgresql.enabled NOT both ) |
 | postgres-operator.operatorApiUrl | string | `"http://{{ .Release.Name }}-postgres-operator:8080"` | ??? |
 | postgres-operator.podServiceAccount | object | `{"name":""}` | not setting the podServiceAccount name will leed to generation of this name. This allows to run multiple postgres-operators in a single kubernetes cluster. just seperating them by namespace. |

--- a/deployment/geonode/templates/geonode/geonode-pvc.yaml
+++ b/deployment/geonode/templates/geonode/geonode-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   accessModes:
-  - ReadWriteMany
+  - {{ .Values.global.accessMode }}
   storageClassName: {{ .Values.global.storageClass }}
   resources:
     requests:

--- a/deployment/geonode/templates/nginx/nginx-ingress.yaml
+++ b/deployment/geonode/templates/nginx/nginx-ingress.yaml
@@ -2,14 +2,18 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name:  "{{ include "nginx_pod_name" . }}-ingress"
-  {{ if ( .Values.geonode.ingress.addNginxIngressAnnotation) }}
   annotations:
+    description: Configures routes for external access
+    {{ if (eq .Values.geonode.acme.enabled true) }}
+    cert-manager.io/issuer: letsencrypt
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    {{ end}}
+    {{ if ( .Values.geonode.ingress.addNginxIngressAnnotation) }}
     nginx.ingress.kubernetes.io/proxy-body-size: "2g"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
-
-  {{ end }}
+    {{ end }}
 spec:
   ingressClassName: {{ .Values.geonode.ingress.ingressClassName }}
   {{ if (eq .Values.geonode.ingress.externalScheme "https") }}
@@ -29,3 +33,27 @@ spec:
             name:  "{{ include "nginx_pod_name" . }}"
             port: 
               number: {{ .Values.geonode.ingress.externalPort }}
+
+---
+
+
+{{if (eq .Values.geonode.acme.enabled true) }}
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: {{ .Values.geonode.acme.email }}
+    server: {{ .Values.geonode.acme.stageUrl }}
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+    - selector:
+        dnsNames:
+          - {{ .Values.geonode.ingress.externalDomain }}
+      http01:
+        ingress:
+          ingressClassName: {{ .Values.geonode.ingress.ingressClassName }}
+{{ end }}

--- a/deployment/geonode/templates/postgres/geonode-manifest.yaml
+++ b/deployment/geonode/templates/postgres/geonode-manifest.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   teamId: {{ .Release.Name | quote }}
   volume:
-    size: {{ .Values.postgres.operator_manifest.storageSize }}
-  numberOfInstances: {{ int .Values.postgres.operator_manifest.numberOfInstances }}
+    size: {{ .Values.postgres.postgres_operator_manifest.storageSize }}
+  numberOfInstances: {{ int .Values.postgres.postgres_operator_manifest.numberOfInstances }}
   users:
     {{ .Values.postgres.username }}:
     - superuser

--- a/deployment/geonode/templates/postgres/geonode-manifest.yaml
+++ b/deployment/geonode/templates/postgres/geonode-manifest.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   teamId: {{ .Release.Name | quote }}
   volume:
-    size: {{ .Values.postgres.postgres_operator_manifest.storageSize }}
-  numberOfInstances: {{ int .Values.postgres.postgres_operator_manifest.numberOfInstances }}
+    size: {{ .Values.postgres.operator_manifest.storageSize }}
+  numberOfInstances: {{ int .Values.postgres.operator_manifest.numberOfInstances }}
   users:
     {{ .Values.postgres.username }}:
     - superuser
@@ -35,4 +35,4 @@ spec:
         pg_partman: {{ .Values.postgres.schema }}
         postgis: {{ .Values.postgres.schema }}
   postgresql:
-    version: {{ .Values.postgres_operator_manifest.postgres_version | quote }}
+    version: {{ .Values.postgres.operator_manifest.postgres_version | quote }}

--- a/deployment/geonode/values.yaml
+++ b/deployment/geonode/values.yaml
@@ -401,7 +401,7 @@ postgres:
 
 
   # -- configuration for postgres operator database manifest
-  postgres_operator_manifest:
+  operator_manifest:
     # -- Database storage size
     storageSize: 3Gi
     # -- number of database instances

--- a/deployment/geonode/values.yaml
+++ b/deployment/geonode/values.yaml
@@ -392,7 +392,7 @@ postgres:
 
 
   # -- configuration for postgres operator database manifest
-  operator_manifest:
+  postgres_operator_manifest:
     # -- Database storage size
     storageSize: 3Gi
     # -- number of database instances
@@ -411,8 +411,8 @@ postgres-operator:
   # -- ???
   operatorApiUrl: "http://{{ .Release.Name }}-postgres-operator:8080"
   configLoggingRestApi:
-  # --  REST API listener listens to this port
-  api_port: 8080
+    # --  REST API listener listens to this port
+    api_port: 8080
   # -- postgress pv storageclass
   storageClass:
   # -- not setting the podServiceAccount name will leed to generation of this name. This allows to run multiple postgres-operators in a single kubernetes cluster. just seperating them by namespace.

--- a/deployment/geonode/values.yaml
+++ b/deployment/geonode/values.yaml
@@ -56,8 +56,17 @@ geonode:
     externalDomain: geonode
     # -- external ingress port
     externalPort: 80
-    # -- tls certificate for geonode ingress https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/. is used when geonode.ingress.externalScheme is set to https
+    # -- tls certificate for geonode ingress https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/ (for the use of cert-manager, configure the acme section properly). is used when geonode.ingress.externalScheme is set to https
     tlsSecret: geonode-tls-secret
+
+  acme:
+    # -- enables cert-manager to do ACME challenges (aka certificates via letsencrypt)
+    enabled: False
+    # -- the email to be used to gain certificates
+    email: support@example.com
+    # -- ACME staging environment (use acme-staging to avoid running into rate limits)
+    #stageUrl: https://acme-v02.api.letsencrypt.org/directory
+    stageUrl: https://acme-staging-v02.api.letsencrypt.org/directory
 
   sentry:
     # -- enable sentry integration for geonode

--- a/minikube-values.yaml
+++ b/minikube-values.yaml
@@ -37,10 +37,11 @@ postgres-operator-ui:
 postgres-operator:
   enabled: True
 
-postgres_operator_manifest:
-  storageSize: 2Gi
-  numberOfInstances: 1
-  postgres_version: 15
+postgres:
+  operator_manifest:
+    storageSize: 2Gi
+    numberOfInstances: 1
+    postgres_version: 15
 
 rabbitmq:
   replicaCount: 1


### PR DESCRIPTION
* postgres-operator failed on AWS EKS due to `could not create cluster: could not create pod disruption budget: the server could not find the requested resource`
* Aligns postgres operator manifest variable name
* Fixes indentation of postgres api_port
* Configures GWC prefix
* Adds optional ACME config for `cert-manager`'s  namespace issuer