### PR TITLE
geonode ingress targets wrong service port when TLS is configured 

### DIFF
--- a/deployment/geonode/templates/nginx/nginx-ingress.yaml
+++ b/deployment/geonode/templates/nginx/nginx-ingress.yaml
@@ -31,8 +31,8 @@ spec:
         backend:
           service:
             name:  "{{ include "nginx_pod_name" . }}"
-            port: 
-              number: {{ .Values.geonode.ingress.externalPort }}
+            port:
+              number: 80
 
 ---
 


### PR DESCRIPTION
The geonode's ingress uses the  `.Values.geonode.ingress.externalPort` to target the geonode nginx service. This is wrong as [the service stays on port `80`](https://github.com/zalf-rdm/geonode-k8s/blob/main/deployment/geonode/templates/nginx/nginx-svc.yaml#L11).


https://github.com/zalf-rdm/geonode-k8s/blob/d748731ee09d5bb310a9c49bcf2c59cd93eeabb7/deployment/geonode/templates/nginx/nginx-ingress.yaml#L29-L36

This results in an HTTP `503` error when ingress is configured [to use TLS (port `443`)](https://github.com/zalf-rdm/geonode-k8s/blob/main/deployment/geonode/values.yaml#L58).

The fix just sets port `80`.