### PR TITLE
Issue#48 remove ingress externalport parameter

### DIFF
--- a/deployment/geonode/README.md
+++ b/deployment/geonode/README.md
@@ -61,7 +61,6 @@ Helm Chart for Geonode
 | geonode.ingress.addNginxIngressAnnotation | bool | `false` | adds ingress annotations for nginx ingress class to increase uploadsize and timeout time |
 | geonode.ingress.enabled | bool | `true` | enables external access  |
 | geonode.ingress.externalDomain | string | `"geonode"` | external ingress hostname  |
-| geonode.ingress.externalPort | int | `80` | external ingress port |
 | geonode.ingress.externalScheme | string | `"http"` | external ingress schema. if set to https ingress tls is used. Loading tls certificate via tls-secret options Available options: (http|https) |
 | geonode.ingress.ingressClassName | string | `nil` | define kubernetes ingress class for geonode ingress |
 | geonode.ingress.tlsSecret | string | `"geonode-tls-secret"` | tls certificate for geonode ingress https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/ (for the use of cert-manager, configure the acme section properly). is used when geonode.ingress.externalScheme is set to https |

--- a/deployment/geonode/templates/_helpers.tpl
+++ b/deployment/geonode/templates/_helpers.tpl
@@ -37,7 +37,7 @@ amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}
 {{- end -}}
 
 {{- define "external_port" -}}
-{{- if or (eq (toString .Values.geonode.ingress.externalPort) "80") (eq (toString .Values.geonode.ingress.externalPort) "443") -}}
+{{- if or ( not .Values.geonode.ingress.externalPort ) (eq (toString .Values.geonode.ingress.externalPort) "80") (eq (toString .Values.geonode.ingress.externalPort) "443") -}}
 {{- else -}}
 :{{ .Values.geonode.ingress.externalPort}}
 {{- end -}}

--- a/deployment/geonode/templates/_helpers.tpl
+++ b/deployment/geonode/templates/_helpers.tpl
@@ -36,15 +36,8 @@ persistence
 amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ include "rabbit_host" . }}/
 {{- end -}}
 
-{{- define "external_port" -}}
-{{- if or ( not .Values.geonode.ingress.externalPort ) (eq (toString .Values.geonode.ingress.externalPort) "80") (eq (toString .Values.geonode.ingress.externalPort) "443") -}}
-{{- else -}}
-:{{ .Values.geonode.ingress.externalPort}}
-{{- end -}}
-{{- end -}}
-
 {{- define "public_url" -}}
-{{ .Values.geonode.ingress.externalScheme }}://{{ .Values.geonode.ingress.externalDomain }}{{ include "external_port" . }}
+{{ .Values.geonode.ingress.externalScheme }}://{{ .Values.geonode.ingress.externalDomain }}
 {{- end -}}
 
 

--- a/deployment/geonode/templates/geonode/geonode-env.yaml
+++ b/deployment/geonode/templates/geonode/geonode-env.yaml
@@ -35,7 +35,6 @@ data:
 
   GEONODE_INSTANCE_NAME: {{ .Release.Name }}
   GEONODE_LB_HOST_IP: {{ .Values.geonode.ingress.externalDomain | quote }}
-  GEONODE_LB_PORT: {{ .Values.geonode.ingress.externalPort | quote }}
   GEONODE_DB_CONN_MAX_AGE: '0'
   GEONODE_DB_CONN_TOUT: '5'
 

--- a/deployment/geonode/templates/geoserver/geoserver-env.yaml
+++ b/deployment/geonode/templates/geoserver/geoserver-env.yaml
@@ -5,10 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   GEONODE_LB_HOST_IP: {{ .Values.geonode.ingress.externalDomain | quote }}
-  GEONODE_LB_PORT: {{ .Values.geonode.ingress.externalPort | quote }}
   GEONODE_HOST_IP: localhost
 
-  PUBLIC_PORT: {{ .Values.geonode.ingress.externalPort | quote }}
   DJANGO_URL: http://{{ include "geonode_pod_name" .}}/
   ENABLE_JSONP: 'true'
   outFormat: text/javascript

--- a/deployment/geonode/templates/nginx/nginx-deploy.yaml
+++ b/deployment/geonode/templates/nginx/nginx-deploy.yaml
@@ -23,11 +23,13 @@ spec:
         image: "{{ .Values.nginx.image.name }}:{{ .Values.nginx.image.tag }}"
 
         ports:
-        # TODO (mwall) may respect {{ .Values.geonode.ingress.externalPort | quote }}
-        - containerPort: 80
-          name: http
+        {{- if (eq .Values.geonode.ingress.externalScheme "https" )}}
         - containerPort: 443
           name: https
+        {{- else }}
+        - containerPort: 80
+          name: http
+        {{- end }}
 
         volumeMounts:
         - name: "{{ include "persistant_volume_name" . }}"

--- a/deployment/geonode/values.yaml
+++ b/deployment/geonode/values.yaml
@@ -54,8 +54,8 @@ geonode:
     externalScheme: http
     # -- external ingress hostname 
     externalDomain: geonode
-    # -- external ingress port
-    externalPort: 80
+    # -- external ingress port (for 443 and 80 this can be left empty)
+    externalPort:
     # -- tls certificate for geonode ingress https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/ (for the use of cert-manager, configure the acme section properly). is used when geonode.ingress.externalScheme is set to https
     tlsSecret: geonode-tls-secret
 

--- a/deployment/geonode/values.yaml
+++ b/deployment/geonode/values.yaml
@@ -54,8 +54,6 @@ geonode:
     externalScheme: http
     # -- external ingress hostname 
     externalDomain: geonode
-    # -- external ingress port (for 443 and 80 this can be left empty)
-    externalPort:
     # -- tls certificate for geonode ingress https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/ (for the use of cert-manager, configure the acme section properly). is used when geonode.ingress.externalScheme is set to https
     tlsSecret: geonode-tls-secret
 

--- a/minikube-values.yaml
+++ b/minikube-values.yaml
@@ -15,7 +15,6 @@ geonode:
     enabled: False
     externalScheme: http
     externalDomain: geonode
-    externalPort: 80
 
   superUser:
     password: geonode


### PR DESCRIPTION
## Description

Remove unnecessary `geonode.ingress.externalPort` parameter. Both http schemes  `http` and `https` have their default ports `80` and `443` which should not be configured explicitly.

ref #48 

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [x] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #48 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

