### PR TITLE
Bugfix bool string confusion in lockdown variable

### DIFF
--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -31,7 +31,7 @@ geonode:
     print("tasks_post_script not defined ...")
 
   accesscontrol:
-    lockdown: False
+    lockdown: "False"
 
   secret:
     # -- name of an existing Secret to use. Set, if you want to separately maintain the Secret.


### PR DESCRIPTION
[Fixes #114] Bug: running a installation with default values breaks at lockdown

## Description

bugfix closes minor type confusion in geonode.lockdown value.

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #114 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request