### PR TITLE
Remove ending slash from NGINX_BASE_URL definition

### DIFF
--- a/charts/geonode/templates/geoserver/geoserver-env.yaml
+++ b/charts/geonode/templates/geoserver/geoserver-env.yaml
@@ -13,7 +13,7 @@ data:
   outFormat: text/javascript
   # trimSuffix trims of suffix "i" coming from resources memory in Gi or Mi
   GEOSERVER_JAVA_OPTS: "-Xms{{ .Values.geoserver.resources.requests.memory | trimSuffix "i" }} -Xmx{{ .Values.geoserver.resources.limits.memory | trimSuffix "i" }} -Djava.awt.headless=true -Dgwc.context.suffix=gwc -XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:LogFile=/var/log/jvm.log -XX:PerfDataSamplingInterval=500 -XX:SoftRefLRUPolicyMSPerMB=36000 -XX:-UseGCOverheadLimit -XX:+UseConcMarkSweepGC -XX:ParallelGCThreads=4 -Dfile.encoding=UTF8 -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -Duser.timezone=GMT -Dorg.geotools.shapefile.datetime=false -DGS-SHAPEFILE-CHARSET=UTF-8 -DGEOSERVER_CSRF_DISABLED=true -DPRINT_BASE_URL={{ include "public_url" . }}/geoserver/pdf -DALLOW_ENV_PARAMETRIZATION=true -Xbootclasspath/a:/usr/local/tomcat/webapps/geoserver/WEB-INF/lib/marlin-0.9.3-Unsafe.jar -Dsun.java2d.renderer=org.marlin.pisces.MarlinRenderingEngine"
-  NGINX_BASE_URL: "{{ include "public_url" . }}/"
+  NGINX_BASE_URL: "{{ include "public_url" . }}"
 
   DATABASE_HOST: "{{ include "database_hostname" . }}"
   DATABASE_PORT: "{{ include "database_port" . }}"


### PR DESCRIPTION
## Description

With an external domain, the geoserver oauth is not working correctly: an error message complains about the redirect_uri which does not match what is registered in geonode, because of an additional /.

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #136 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request