### PR TITLE
[Fixes #107] Task: revert changes regarding geoserver entrypoint overloading gefence file

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ helm upgrade --cleanup-on-fail   --install --namespace geonode --create-namespac
 
 ## Delete Installation
 ```bash
-helm delete --namespace geonode geonode charts/geonode
+helm delete --namespace geonode geonode geonode
 ```
 
 ## Contribution

--- a/charts/geonode/templates/geoserver/geoserver-deploy.yaml
+++ b/charts/geonode/templates/geoserver/geoserver-deploy.yaml
@@ -58,14 +58,6 @@ spec:
       - name: {{ .Values.geoserver.container_name }}
         image: "{{ .Values.geoserver.image.name }}:{{ .Values.geoserver.image.tag }}"
         # temporary overloading entry point to fix j2 template: https://github.com/GeoNode/geonode/issues/11318
-        command:
-        - sh
-        - -c
-        - |
-          TMP_DB_PORT={{ include "database_port" . }}
-          {{`sed -i 's/db:5432/{{ DATABASE_HOST }}:$TMP_DB_PORT/g' /templates/geofence/geofence-datasource-ovr.properties.j2`}}
-          /usr/local/tomcat/tmp/entrypoint.sh
-
         ports:
         - containerPort: {{ .Values.geoserver.port }}
 

--- a/charts/geonode/templates/geoserver/geoserver-deploy.yaml
+++ b/charts/geonode/templates/geoserver/geoserver-deploy.yaml
@@ -57,7 +57,6 @@ spec:
       containers:
       - name: {{ .Values.geoserver.container_name }}
         image: "{{ .Values.geoserver.image.name }}:{{ .Values.geoserver.image.tag }}"
-        # temporary overloading entry point to fix j2 template: https://github.com/GeoNode/geonode/issues/11318
         ports:
         - containerPort: {{ .Values.geoserver.port }}
 


### PR DESCRIPTION
## Description

removed manual gefence fix referenced in geonode issue https://github.com/GeoNode/geonode/issues/11318 . refers to geonode-k8s issue #107 

THIS will take in affect with the next release, as it requires geonode 4.2 image

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #107 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request