### PR TITLE
[Fixes #105] Task:make postgres operator installation optional

### DIFF
--- a/charts/geonode/Chart.yaml
+++ b/charts/geonode/Chart.yaml
@@ -36,10 +36,6 @@ maintainers:
     email: marcel.wallschlaeger@zalf.de
     url: https://github.com/mwallschlaeger
 dependencies:
-  - name: postgres-operator-ui
-    version: ~1.9.0
-    repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui/
-    condition: postgres-operator-ui.enabled
   - name: postgres-operator
     version: ~1.9.0
     repository: https://opensource.zalando.com/postgres-operator/charts/postgres-operator/

--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -23,7 +23,6 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.1.3, Geoserver: 2.23.0, p
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | memcached | ~6.x.x |
 | https://charts.bitnami.com/bitnami | rabbitmq | ~10.1.7 |
-| https://opensource.zalando.com/postgres-operator/charts/postgres-operator-ui/ | postgres-operator-ui | ~1.9.0 |
 | https://opensource.zalando.com/postgres-operator/charts/postgres-operator/ | postgres-operator | ~1.9.0 |
 
 ## Values
@@ -31,7 +30,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.1.3, Geoserver: 2.23.0, p
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | favicon | string | AAABAAMAEBAAAAEAIABoBA ... AAAA== | A base64 encoded favicon |
-| geonode.accesscontrol.lockdown | bool | `false` | Enable/Disable lockdown mode of GeoNode |
+| geonode.accesscontrol.lockdown | string | `"False"` | Enable/Disable lockdown mode of GeoNode |
 | geonode.acme.email | string | `"support@example.com"` | the email to be used to gain certificates |
 | geonode.acme.enabled | bool | `false` | enables cert-manager to do ACME challenges (aka certificates via letsencrypt) |
 | geonode.acme.stageUrl | string | `"https://acme-staging-v02.api.letsencrypt.org/directory"` | ACME staging environment (use acme-staging to avoid running into rate limits) stageUrl: https://acme-v02.api.letsencrypt.org/directory |
@@ -68,7 +67,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.1.3, Geoserver: 2.23.0, p
 | geonode.haystack.search_results_per_page | string | `"200"` | hystack results per page |
 | geonode.image.name | string | `"52north/geonode"` | used geonode image |
 | geonode.image.tag | string | `"4.1.3"` | tag of used geonode image |
-| geonode.imagePullSecret | string | `""` | secret to use to pull geonode image |
+| geonode.imagePullSecret | string | `""` | pull secret to use for geonode image |
 | geonode.ingress.annotations | object | `{}` | adds ingress annotations for nginx ingress class |
 | geonode.ingress.enabled | bool | `true` | enables external access |
 | geonode.ingress.ingressClassName | string | `nil` | define kubernetes ingress class for geonode ingress |
@@ -142,7 +141,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.1.3, Geoserver: 2.23.0, p
 | geoserver.container_name | string | `"geoserver"` | geoserver container name |
 | geoserver.image.name | string | `"geonode/geoserver"` | geoserver image docker image (default in zalf namespace because geonode one was not up to date) |
 | geoserver.image.tag | string | `"2.23.0"` | geoserver docker image tag |
-| geoserver.imagePullSecret | string | `""` | secret to use to pull geoserver image |
+| geoserver.imagePullSecret | string | `""` | pull secret to use for geoserver image |
 | geoserver.pod_name | string | `"geoserver"` | geoserver pod name |
 | geoserver.port | int | `8080` | geoserver port |
 | geoserver.resources.limits.cpu | int | `2` | limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
@@ -161,7 +160,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.1.3, Geoserver: 2.23.0, p
 | nginx.external_cors.enabled | bool | `false` | Add Access-Control-Allow-Origin directive to allow integration from an external domain |
 | nginx.image.name | string | `"nginx"` | nginx docker image |
 | nginx.image.tag | string | `"1.25"` | nginx docker image tag |
-| nginx.imagePullSecret | string | `""` | secret to use to pull nginx image |
+| nginx.imagePullSecret | string | `""` | pull secret to use for nginx image |
 | nginx.maxClientBodySize | string | `"2G"` | max file upload size |
 | nginx.pod_name | string | `"nginx"` | nginx pod name |
 | nginx.replicaCount | int | `1` | nginx container replicas |
@@ -169,34 +168,25 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.1.3, Geoserver: 2.23.0, p
 | nginx.resources.limits.memory | string | `"1Gi"` | limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | nginx.resources.requests.cpu | string | `"500m"` | requested cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | nginx.resources.requests.memory | string | `"1Gi"` | requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
-| postgres-operator-ui.enabled | bool | `false` |  |
-| postgres-operator-ui.envs.operatorApiUrl | string | `"http://{{ $.Release.Name }}-postgres-operator:8080"` |  |
-| postgres-operator-ui.ingress.enabled | bool | `false` |  |
-| postgres-operator-ui.ingress.hosts[0].host | string | `"postgres-ui"` |  |
-| postgres-operator-ui.ingress.hosts[0].paths[0] | string | `""` |  |
-| postgres-operator-ui.ingress.ingressClassName | string | `nil` |  |
-| postgres-operator-ui.replicaCount | int | `1` |  |
-| postgres-operator-ui.service.port | int | `80` |  |
-| postgres-operator-ui.service.type | string | `"ClusterIP"` |  |
 | postgres-operator.configLoggingRestApi.api_port | int | `8080` | REST API listener listens to this port |
 | postgres-operator.enabled | bool | `true` | enable postgres-operator (this or postgresql.enabled NOT both ) |
 | postgres-operator.operatorApiUrl | string | `"http://{{ .Release.Name }}-postgres-operator:8080"` | ??? |
 | postgres-operator.podServiceAccount | object | `{"name":""}` | not setting the podServiceAccount name will leed to generation of this name. This allows to run multiple postgres-operators in a single kubernetes cluster. just seperating them by namespace. |
 | postgres-operator.storageClass | string | `nil` | postgress pv storageclass |
-| postgres.external_postgres.enabled | bool | `false` |  |
-| postgres.external_postgres.hostname | string | `"my-external-postgres.com"` |  |
-| postgres.external_postgres.port | int | `5432` |  |
-| postgres.external_postgres.secret.existingSecretName | string | `""` | name of an existing Secret to use. Set, if you want to separately maintain the Secret. |
-| postgres.external_postgres.secret.geodata_password | string | `"geogeonode"` |  |
-| postgres.external_postgres.secret.geonode_password | string | `"geonode"` |  |
-| postgres.external_postgres.secret.postgres_password | string | `"postgres"` |  |
+| postgres.external.hostname | string | `"my-external-postgres.com"` |  |
+| postgres.external.port | int | `5432` |  |
+| postgres.external.secret.existingSecretName | string | `""` | name of an existing Secret to use. Set, if you want to separately maintain the Secret. |
+| postgres.external.secret.geodata_password | string | `"geogeonode"` |  |
+| postgres.external.secret.geonode_password | string | `"geonode"` |  |
+| postgres.external.secret.postgres_password | string | `"postgres"` |  |
 | postgres.geodata_databasename_and_username | string | `"geodata"` | geoserver database name and username |
 | postgres.geonode_databasename_and_username | string | `"geonode"` | geonode database name and username |
-| postgres.operator_manifest.numberOfInstances | int | `1` | number of database instances |
-| postgres.operator_manifest.pod_name | string | `"postgresql"` | pod name for postgres containers == teamID for mainifest |
-| postgres.operator_manifest.postgres_version | int | `15` | postgres version |
-| postgres.operator_manifest.storageSize | string | `"3Gi"` | Database storage size |
+| postgres.operator.numberOfInstances | int | `1` | number of database instances |
+| postgres.operator.pod_name | string | `"postgresql"` | pod name for postgres containers == teamID for mainifest |
+| postgres.operator.postgres_version | int | `15` | postgres version |
+| postgres.operator.storageSize | string | `"3Gi"` | Database storage size |
 | postgres.schema | string | `"public"` | database schema |
+| postgres.type | string | `"operator"` | type of used postgres: "operator" or "external". \ if external is used, host, port and password have to be set in postgres.external using values or external secret if operator is used, host port and passwords get set automatically using postgres-operator. If your Kubernetes cluster does not have a running postgres-operator, you can install the postgres-operator with  postgres-operator.enabled = true |
 | postgres.username | string | `"postgres"` | postgres username |
 | pycsw.config | string | based of pycsw example.cfg: https://github.com/geopython/pycsw/blob/master/docker/pycsw.cfg | pycsw config file parameters, see docs: https://docs.pycsw.org/_/downloads/en/latest/pdf/ |
 | pycsw.container_name | string | `"pycsw"` | pycsw container name |
@@ -204,7 +194,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.1.3, Geoserver: 2.23.0, p
 | pycsw.endpoint | string | `"/catalogue/csw"` | pycsw url below geonode.ingress.externalDomain |
 | pycsw.image.name | string | `"geopython/pycsw"` | pycsw docker image |
 | pycsw.image.tag | string | `"2.6.1"` | pycsw docker image tag |
-| pycsw.imagePullSecret | string | `""` | secret to use to pull pycsw image |
+| pycsw.imagePullSecret | string | `""` | pull secret to use for pycsw image |
 | pycsw.mappings | string | copied from 4.1.x: https://github.com/GeoNode/geonode/blob/master/geonode/catalogue/backends/pycsw_local_mappings.py | pycsw config file parameters, see docs: https://docs.pycsw.org/_/downloads/en/latest/pdf/ |
 | pycsw.pod_name | string | `"pysw"` | pycsw pod name |
 | pycsw.port | int | `8000` | pycsw endpoint port |
@@ -227,4 +217,4 @@ Helm Chart for Geonode. Supported versions: Geonode: 4.1.3, Geoserver: 2.23.0, p
 | rabbitmq.requests.memory | string | `"1Gi"` | requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.3](https://github.com/norwoodj/helm-docs/releases/v1.11.3)
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/geonode/templates/_helpers.tpl
+++ b/charts/geonode/templates/_helpers.tpl
@@ -9,7 +9,7 @@
 {{- end -}}
 
 {{- define "postgres_pod_name" -}}
-{{ .Release.Name }}-{{ .Values.postgres.operator_manifest.pod_name }}
+{{ .Release.Name }}-{{ .Values.postgres.operator.pod_name }}
 {{- end -}}
 
 {{- define "nginx_pod_name" -}}
@@ -29,77 +29,77 @@
 
 # Database definitions
 {{- define "database_hostname" -}}
-{{- if (index .Values "postgres-operator" "enabled") -}}
+{{- if (eq .Values.postgres.type "operator") -}}
 {{ include "postgres_pod_name" . }}
-{{- else if .Values.postgres.external_postgres.enabled -}}
-{{- .Values.postgres.external_postgres.hostname -}}
+{{- else if (eq .Values.postgres.type "external") -}}
+{{- .Values.postgres.external.hostname -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "database_port" -}}
-{{- if (index .Values "postgres-operator" "enabled") -}}
+{{- if (eq .Values.postgres.type "operator") -}}
 5432
-{{- else if .Values.postgres.external_postgres.enabled -}}
-{{ .Values.postgres.external_postgres.port }}
+{{- else if (eq .Values.postgres.type "external") -}}
+{{ .Values.postgres.external.port }}
 {{- end -}}
 {{- end -}}
 
 # secret key reference for the password of user:  .Values.postgres.username
 {{- define "database_postgres_password_secret_key_ref" -}}
-{{- if (index .Values "postgres-operator" "enabled") -}}
+{{- if (eq .Values.postgres.type "operator") -}}
 "{{ .Values.postgres.username }}.{{ include "postgres_pod_name" . }}.credentials.postgresql.acid.zalan.do"
-{{- else if and .Values.postgres.external_postgres.enabled (not .Values.postgres.external_postgres.secret.existingSecretName ) -}}
+{{- else if and (eq .Values.postgres.type "external") (not .Values.postgres.external.secret.existingSecretName ) -}}
 "{{ .Release.Name }}-postgres-external-secrets"
 {{- else -}}
-"{{.Values.postgres.external_postgres.secret.existingSecretName }}"
+"{{.Values.postgres.external.secret.existingSecretName }}"
 {{- end -}}
 {{- end -}}
 
 # secret key reference for the password of user:  .Values.postgres.geonode_databasename_and_username
 {{- define "database_geonode_password_secret_key_ref" -}}
-{{- if (index .Values "postgres-operator" "enabled") -}}
+{{- if (eq .Values.postgres.type "operator") -}}
 "{{ .Values.postgres.geonode_databasename_and_username }}.{{ include "postgres_pod_name" . }}.credentials.postgresql.acid.zalan.do"
-{{- else if and .Values.postgres.external_postgres.enabled (not .Values.postgres.external_postgres.secret.existingSecretName ) -}}
+{{- else if and (eq .Values.postgres.type "external") (not .Values.postgres.external.secret.existingSecretName ) -}}
 "{{ .Release.Name }}-geonode-external-secrets"
 {{- else -}}
-"{{.Values.postgres.external_postgres.secret.existingSecretName }}"
+"{{.Values.postgres.external.secret.existingSecretName }}"
 {{- end -}}
 {{- end -}}
 
 # secret key reference for the password of user: .Values.postgres.geodata_databasename_and_username
 {{- define "database_geodata_password_secret_key_ref" -}}
-{{- if (index .Values "postgres-operator" "enabled") -}}
+{{- if (eq .Values.postgres.type "operator") -}}
 "{{ .Values.postgres.geodata_databasename_and_username }}.{{ include "postgres_pod_name" . }}.credentials.postgresql.acid.zalan.do"
-{{- else if and .Values.postgres.external_postgres.enabled (not .Values.postgres.external_postgres.secret.existingSecretName ) -}}
+{{- else if and (eq .Values.postgres.type "external") (not .Values.postgres.external.secret.existingSecretName ) -}}
 "{{ .Release.Name }}-geodata-external-secrets"
-{{- else -}}
-"{{.Values.postgres.external_postgres.secret.existingSecretName }}"
+{{- else if .Values.postgres.external.secret.existingSecretName -}}
+"{{.Values.postgres.external.secret.existingSecretName }}"
 {{- end -}}
 {{- end -}}
 
 # define password key name in geonode postgres secret
 {{- define "database_geonode_password_key_ref" -}}
-{{- if (index .Values "postgres-operator" "enabled") -}}
+{{- if (eq .Values.postgres.type "operator") -}}
 password
-{{- else if .Values.postgres.external_postgres.enabled -}}
+{{- else if (eq .Values.postgres.type "external") -}}
 geonode-password
 {{- end -}}
 {{- end -}}
 
 # define password key name in geodata postgres secret
 {{- define "database_geodata_password_key_ref" -}}
-{{- if (index .Values "postgres-operator" "enabled") -}}
+{{- if (eq .Values.postgres.type "operator") -}}
 password
-{{- else if .Values.postgres.external_postgres.enabled -}}
+{{- else if (eq .Values.postgres.type "external") -}}
 geodata-password
 {{- end -}}
 {{- end -}}
 
 # define password key name in postgres postgres secret
 {{- define "database_postgres_password_key_ref" -}}
-{{- if (index .Values "postgres-operator" "enabled") -}}
+{{- if (eq .Values.postgres.type "operator") -}}
 password
-{{- else if .Values.postgres.external_postgres.enabled -}}
+{{- else if (eq .Values.postgres.type "external") -}}
 postgres-password
 {{- end -}}
 {{- end -}}

--- a/charts/geonode/templates/geonode/geonode-deploy.yaml
+++ b/charts/geonode/templates/geonode/geonode-deploy.yaml
@@ -1,17 +1,9 @@
-# check if external and postgres-operator database backends are active
-{{ $postgres_operator := index .Values "postgres-operator" "enabled" }}
-{{ $postgres_operator_ui := index .Values "postgres-operator-ui" "enabled"}}
-# check if multiple database backends are active
-{{ if and .Values.postgres.external_postgres.enabled $postgres_operator }}
-  {{- fail "Error, two Database backends enabled, check .Values.postgres.external_postgres or .Values.postgres-operator ..." }}
-{{ else if  and (not .Values.postgres.external_postgres.enabled) (not $postgres_operator) }}
-  {{- fail "Error, no Database backend is enabled, check .Values.postgres.external_postgres or .Values.postgres-operator ..." }}
+# check if postgres.type is set to external operator
+{{ $is_operator := (eq .Values.postgres.type "operator") }}
+{{ $is_external := (eq .Values.postgres.type "external") }}
+{{ if not (or $is_operator  $is_external) }}
+  {{- fail "Deploymnent FAILED, unknown postgres.type defined, please set postgres.type to operator or external ..." }}
 {{ end }}
-# check if operator ui is activated even postgres-operator is disabled
-{{ if and ($postgres_operator_ui) (not $postgres_operator) }}
-  {{- fail "Error, postgres-operator-ui enabled even postgres-operator ist disabled ..." }}
-{{ end }}
-
 
 # geonode stateful set
 apiVersion: apps/v1
@@ -105,17 +97,17 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ include "database_geonode_password_secret_key_ref" . }}
-              key: password
+              key: {{ include "database_geonode_password_key_ref" . }}
         - name: GEONODE_GEODATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "database_geodata_password_secret_key_ref" . }}
-              key: password
+              key: {{ include "database_geodata_password_key_ref" . }}
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "database_postgres_password_secret_key_ref" . }}
-              key: password
+              key: {{ include "database_postgres_password_key_ref" . }}
         - name: GEODATABASE_URL
           value: "postgis://$(GEONODE_GEODATABASE):$(GEONODE_GEODATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(GEONODE_GEODATABASE)"
         - name: DATABASE_URL

--- a/charts/geonode/templates/postgres/postgres-external-geodata-secrets.yaml
+++ b/charts/geonode/templates/postgres/postgres-external-geodata-secrets.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.postgres.external_postgres.enabled (not .Values.postgres.external_postgres.secret.existingSecretName )}}
+{{ if and (eq .Values.postgres.type "external") (not .Values.postgres.external.secret.existingSecretName )}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  geodata_password: {{ .Values.postgres.external_postgres.secret.geodata_password | b64enc }}
+  geodata_password: {{ .Values.postgres.external.secret.geodata_password | b64enc }}
 {{ end }}

--- a/charts/geonode/templates/postgres/postgres-external-geonode-secrets.yaml
+++ b/charts/geonode/templates/postgres/postgres-external-geonode-secrets.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.postgres.external_postgres.enabled (not .Values.postgres.external_postgres.secret.existingSecretName )}}
+{{ if and (eq .Values.postgres.type "external") (not .Values.postgres.external.secret.existingSecretName )}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  geonode_password: {{ .Values.postgres.external_postgres.secret.geonode_password | b64enc }}
+  geonode_password: {{ .Values.postgres.external.secret.geonode_password | b64enc }}
 {{ end }}

--- a/charts/geonode/templates/postgres/postgres-external-postgres-secrets.yaml
+++ b/charts/geonode/templates/postgres/postgres-external-postgres-secrets.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.postgres.external_postgres.enabled (not .Values.postgres.external_postgres.secret.existingSecretName )}}
+{{ if and (eq .Values.postgres.type "external") (not .Values.postgres.external.secret.existingSecretName )}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  postgres_password: {{ .Values.postgres.external_postgres.secret.postgres_password | b64enc }}
+  postgres_password: {{ .Values.postgres.external.secret.postgres_password | b64enc }}
 {{ end }}

--- a/charts/geonode/templates/postgres/postgresql-operator.yaml
+++ b/charts/geonode/templates/postgres/postgresql-operator.yaml
@@ -1,6 +1,5 @@
 
-{{ $postgres_operator := index .Values "postgres-operator" "enabled" }}
-{{ if $postgres_operator }}
+{{- if eq .Values.postgres.type "operator" -}}
 apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
@@ -8,8 +7,8 @@ metadata:
 spec:
   teamId: {{ .Release.Name | quote }}
   volume:
-    size: {{ .Values.postgres.operator_manifest.storageSize }}
-  numberOfInstances: {{ int .Values.postgres.operator_manifest.numberOfInstances }}
+    size: {{ .Values.postgres.operator.storageSize }}
+  numberOfInstances: {{ int .Values.postgres.operator.numberOfInstances }}
   users:
     {{ .Values.postgres.username }}:
     - superuser
@@ -38,5 +37,5 @@ spec:
         pg_partman: {{ .Values.postgres.schema }}
         postgis: {{ .Values.postgres.schema }}
   postgresql:
-    version: {{ .Values.postgres.operator_manifest.postgres_version | quote }}
+    version: {{ .Values.postgres.operator.postgres_version | quote }}
 {{ end }}

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -591,6 +591,11 @@ rabbitmq:
     cpu: "750m"
 
 postgres:
+  # -- type of used postgres: "operator" or "external". \
+  # if external is used, host, port and password have to be set in postgres.external using values or external secret
+  # if operator is used, host port and passwords get set automatically using postgres-operator. If your Kubernetes cluster
+  # does not have a running postgres-operator, you can install the postgres-operator with  postgres-operator.enabled = true
+  type: operator
   # -- postgres username
   username: postgres
   # -- database schema
@@ -601,7 +606,7 @@ postgres:
   geodata_databasename_and_username: geodata
 
   # configuration for postgres operator database manifest
-  operator_manifest:
+  operator:
     # -- pod name for postgres containers == teamID for mainifest
     pod_name: postgresql
     # -- Database storage size
@@ -614,8 +619,7 @@ postgres:
     # infos @ https://postgres-operator.readthedocs.io/en/refactoring-sidecars/user/
     # get password after creation via: kubectl get secret {{ .Release.name }}.{{ .Release.name }}-{{ container_name }}.credentials -o 'jsonpath={.data.password}' | base64 -d
 
-  external_postgres:
-    enabled: False
+  external:
     hostname: my-external-postgres.com
     port: 5432
     secret:
@@ -639,22 +643,6 @@ postgres-operator:
   # -- not setting the podServiceAccount name will leed to generation of this name. This allows to run multiple postgres-operators in a single kubernetes cluster. just seperating them by namespace.
   podServiceAccount:
     name: ""
-
-# VALUES DEFINITION: https://github.com/zalando/postgres-operator/blob/master/charts/postgres-operator-ui/values.yaml
-postgres-operator-ui:
-  enabled: False
-  replicaCount: 1
-  envs:
-    operatorApiUrl: "http://{{ $.Release.Name }}-postgres-operator:8080"
-  service:
-    type: ClusterIP
-    port: 80
-  ingress:
-    enabled: False
-    ingressClassName:
-    hosts:
-      - host: postgres-ui
-        paths: [""]
 
 # -- (map of fixture files) Fixture files which shall be made available under /usr/src/geonode/geonode/fixtures (refer to https://docs.djangoproject.com/en/4.2/howto/initial-data/)
 geonodeFixtures:

--- a/docs/external-database.md
+++ b/docs/external-database.md
@@ -56,12 +56,12 @@ Now you have to configure your values.yaml to use this external database. You ca
 
 ```
 postgres:
+  type: external
   username: postgres
   geonode_databasename_and_username: geonode
   geodata_databasename_and_username: geodata
 
-  external_postgres:
-    enabled: True
+  external:
     hostname: my-external-postgres.com
     port: 5432
     postgres_password: 

--- a/minikube-values-external-db.yaml
+++ b/minikube-values-external-db.yaml
@@ -38,18 +38,18 @@ rabbitmq:
     password: rabbit_password
 
 postgres:
+  type: external
   username: postgres
   geonode_databasename_and_username: geonode
   geodata_databasename_and_username: geodata
 
-  external_postgres:
-    enabled: True
+  external:
     hostname: "external-postgres.com"
     port: 5432
     secret:
-      postgres_password:
-      geonode_password:
-      geodata_password:
+      postgres_password: please-fill-out
+      geonode_password: please-fill-out
+      geodata_password: please-fill-out
+
 postgres-operator:
   enabled: False
-

--- a/minikube-values-external-db.yaml
+++ b/minikube-values-external-db.yaml
@@ -47,9 +47,9 @@ postgres:
     hostname: "external-postgres.com"
     port: 5432
     secret:
-      postgres_password: please-fill-out
-      geonode_password: please-fill-out
-      geodata_password: please-fill-out
+      postgres_password:
+      geonode_password:
+      geodata_password:
 
 postgres-operator:
   enabled: False

--- a/minikube-values.yaml
+++ b/minikube-values.yaml
@@ -34,14 +34,12 @@ geonode:
 pycsw:
   enabled: False
 
-postgres-operator-ui:
-  enabled: False
-
 postgres-operator:
   enabled: True
 
 postgres:
-  operator_manifest:
+  type: operator
+  operator:
     storageSize: 2Gi
     numberOfInstances: 1
     postgres_version: 15


### PR DESCRIPTION
## Description

**CHANGED VALUES.YAML. This may not be compatible with previous versions.**

This issue target the situation that you already have a postgres-operator running in your cluster and want to use it without using the external database configuration in geonode-k8s.

So from now on user can choose what kind of postgres type the gonna use by setting the `postgres.type` variable ether to `operator` or `external`. If your're using the operator you can further decide to install the postgres-operator into your cluster by setting the  `postgres-operator.enabled = True`, if not geonode-k8s expects a postgres operator to be available inside your cluster.
When setting `postgres.type` to `external` you need to set your database passwords inside the values.yaml like describe in docs/external_database or provide an self spinned secret set defined in: `postgres.external.secret.existingSecretName`.

1. operator example **without** installing the operator when installing geonode-k8s:
```
postgres-operator:
  enabled: False

postgres:
  type: operator
  operator:
    storageSize: 2Gi
    numberOfInstances: 1
    postgres_version: 15
```
2. operator example **with** installing the operator when installing geonode-k8s (default in minikube-values.yaml):
```
postgres-operator:
  enabled: True

postgres:
  type: operator
  operator:
    storageSize: 2Gi
    numberOfInstances: 1
    postgres_version: 15
```
3. external example setting db passwords in values.yaml (default in minikube-values-external-db.yaml):
```
postgres:
  type: external
  username: postgres
  geonode_databasename_and_username: geonode
  geodata_databasename_and_username: geodata

  external:
    hostname: "external-postgres.com"
    port: 5432
    secret:
      postgres_password: please-fill-out
      geonode_password: please-fill-out
      geodata_password: please-fill-out

postgres-operator:
  enabled: False
```
4. external example setting db passwords in beforehand configured secret:
```
postgres:
  type: external
  username: postgres
  geonode_databasename_and_username: geonode
  geodata_databasename_and_username: geodata

  external:
    hostname: "external-postgres.com"
    port: 5432
    secret:
      existingSecretName: "geonode-postgres-db-passwords"

postgres-operator:
  enabled: False
```

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #105 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request