### PR TITLE
When using external DB, allow to configure ssl mode

### DIFF
--- a/charts/geonode/templates/_helpers.tpl
+++ b/charts/geonode/templates/_helpers.tpl
@@ -48,6 +48,14 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "database_ssl" -}}
+{{- if (eq .Values.postgres.type "operator") -}}
+require
+{{- else if (eq .Values.postgres.type "external") -}}
+{{ .Values.postgres.external.ssl }}
+{{- end -}}
+{{- end -}}
+
 # secret key reference for the password of user:  .Values.postgres.username
 {{- define "database_postgres_password_secret_key_ref" -}}
 {{- if (eq .Values.postgres.type "operator") -}}

--- a/charts/geonode/templates/geonode/geonode-env.yaml
+++ b/charts/geonode/templates/geonode/geonode-env.yaml
@@ -181,7 +181,7 @@ data:
   DATABASE_PORT: {{ include "database_port" . | quote }}
 
   # enables ssl encrypted psql connection (required by postgres-operator databases)
-  PGSSLMODE: "require"
+  PGSSLMODE: {{ include "database_ssl" . | quote }}
   POSTGRES_USER: {{ .Values.postgres.username | quote }}
   GEONODE_DATABASE: {{ .Values.postgres.geonode_databasename_and_username | quote }}
   GEONODE_GEODATABASE: {{ .Values.postgres.geodata_databasename_and_username | quote }}

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -658,6 +658,7 @@ postgres:
   external:
     hostname: my-external-postgres.com
     port: 5432
+    ssl: prefer
     secret:
       # -- name of an existing Secret to use. Set, if you want to separately maintain the Secret.
       existingSecretName: ""


### PR DESCRIPTION
## Description

Change management of PG SSL mode option for geonode:
- When using operator, force it to "require"
- When using external, use the value provided by values.yaml with a default value to "prefer", to restore the previous behavior

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #166 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request