### PR TITLE
fix(geonode): multi-line tasks script indentation

### DIFF
--- a/charts/geonode/templates/geonode/geonode-tasks-py-conf.yaml
+++ b/charts/geonode/templates/geonode/geonode-tasks-py-conf.yaml
@@ -427,12 +427,12 @@ data:
     @task
     def prescript(ctx):
         print("**********************geonode-k8s pre ***************************")
-        {{ .Values.geonode.tasks_pre_script }}
+        {{ .Values.geonode.tasks_pre_script | indent 8 | trim }}
 
     @task
     def postscript(ctx):
         print("**********************geonode-k8s post ***************************")
-        {{ .Values.geonode.tasks_post_script }}
+        {{ .Values.geonode.tasks_post_script | indent 8 | trim }}
 
 
     def _update_db_connstring():


### PR DESCRIPTION
## Description

Without the fix, only the first line in a multi-line script is indented causing an error when creating the configmap.

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

https://github.com/zalf-rdm/geonode-k8s/issues/214

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

n/a
