### PR TITLE
Ingress pycsw: Repair indentation

### DIFF
--- a/charts/geonode/templates/nginx/nginx-ingress.yaml
+++ b/charts/geonode/templates/nginx/nginx-ingress.yaml
@@ -40,7 +40,7 @@ spec:
             name: "{{ include "geoserver_pod_name" . }}"
             port:
               number: {{ .Values.geoserver.port }}
-  {{ if .Values.pycsw.enabled }}
+      {{- if .Values.pycsw.enabled }}
       - path: {{ .Values.pycsw.endpoint }}
         pathType: Prefix
         backend:
@@ -48,7 +48,7 @@ spec:
             name: "{{ include "pycsw_pod_name" . }}"
             port:
               number: 8000
-  {{ end }}
+      {{- end }}
 
 ---
 


### PR DESCRIPTION
## Description

In the current template, the catalogue csw ingress rule is not taken into account, this pull request fixes that.
Can be tested with:
kubectl get ingress geonode-nginx-ingress -n geonode -o yaml | grep -A 30 "paths:"

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request