### PR TITLE
Allow to override the host being called for nominatim searches

### DIFF
--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -93,6 +93,9 @@ Helm Chart for Geonode. Supported versions: Geonode: 5.0.1, Geoserver: 2.27.4-la
 | geonode.mail.port | string | `"587"` | mail port fo geonode mail |
 | geonode.mail.tls | bool | `true` | activate tls for geonode mail (only tls or ssl can be true not both) |
 | geonode.mail.use_ssl | bool | `false` | enable ssl for geonode mail (only tls or ssl can be true not both) |
+| geonode.mapstore.nominatim_patch.enabled | bool | `false` | enable patch to override nominatim geographical search backend host name |
+| geonode.mapstore.nominatim_patch.host | string | `"someotherhost.example.com"` | host name for geographical searches with nominatim |
+| geonode.mapstore.nominatim_patch.protocol | string | `"https"` | protocol for geographical searches with nominatim |
 | geonode.memcached.backend | string | `"django.core.cache.backends.memcached.PyLibMCCache"` | memcached backend to use if geonode ">=4.3.0" use django.core.cache.backends.memcached.PyLibMCCache before use django.core.cache.backends.memcached.MemcachedCache |
 | geonode.memcached.enabled | bool | `true` | enable memcache, this will spawn one or more seperate memcache container(s) |
 | geonode.memcached.enabled_geonode | bool | `false` | set the MEMCACHED_ENABLED env var for GeoNode (django). Dynamic caching (see https://docs.djangoproject.com/en/4.0/topics/cache/) |

--- a/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
+++ b/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
@@ -44,7 +44,7 @@ spec:
           echo "-----------------------------------------------------"
           echo "GeoNode static tasks done $(date)"
           echo "-----------------------------------------------------"
-{{- if .Values.geonode.mapstore_nominatim_patch.enabled }}
+{{- if .Values.geonode.mapstore.nominatim_patch.enabled }}
           echo "-----------------------------------------------------"
           echo "Applying Mapstore Nominatim patch $(date)"
           echo "-----------------------------------------------------"
@@ -97,7 +97,7 @@ spec:
           mountPath: "/usr/src/geonode/geonode/geonode-k8s-settings-additions.py"
           subPath: geonode-k8s-settings-additions.py
           readOnly: true
-{{- if .Values.geonode.mapstore_nominatim_patch.enabled }}
+{{- if .Values.geonode.mapstore.nominatim_patch.enabled }}
         - name: mapstore-nominatim-patch-py
           mountPath: /usr/src/geonode/mapstore_nominatim_patch.py
           subPath: mapstore_nominatim_patch.py
@@ -130,7 +130,7 @@ spec:
           items:
           - key: geonode-k8s-settings-additions.py
             path: "geonode-k8s-settings-additions.py"
-{{- if .Values.geonode.mapstore_nominatim_patch.enabled }}
+{{- if .Values.geonode.mapstore.nominatim_patch.enabled }}
       - name: mapstore-nominatim-patch-py
         configMap:
           name: "{{ include "geonode_pod_name" . }}-mapstore-nominatim-patch"

--- a/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
+++ b/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
@@ -44,6 +44,15 @@ spec:
           echo "-----------------------------------------------------"
           echo "GeoNode static tasks done $(date)"
           echo "-----------------------------------------------------"
+{{- if .Values.geonode.mapstore_nominatim_patch.enabled }}
+          echo "-----------------------------------------------------"
+          echo "Applying Mapstore Nominatim patch $(date)"
+          echo "-----------------------------------------------------"
+          python3 /usr/src/geonode/mapstore_nominatim_patch.py
+          echo "-----------------------------------------------------"
+          echo "Mapstore Nominatim patch done $(date)"
+          echo "-----------------------------------------------------"
+{{- end }}
         envFrom:
         - configMapRef:
             name: {{ include "geonode_pod_name" . }}-env
@@ -88,6 +97,12 @@ spec:
           mountPath: "/usr/src/geonode/geonode/geonode-k8s-settings-additions.py"
           subPath: geonode-k8s-settings-additions.py
           readOnly: true
+{{- if .Values.geonode.mapstore_nominatim_patch.enabled }}
+        - name: mapstore-nominatim-patch-py
+          mountPath: /usr/src/geonode/mapstore_nominatim_patch.py
+          subPath: mapstore_nominatim_patch.py
+          readOnly: true
+{{- end }}
         - name: "{{ include "persistant_volume_name" . }}"
           mountPath: /mnt/volumes/statics
           subPath: statics
@@ -115,6 +130,11 @@ spec:
           items:
           - key: geonode-k8s-settings-additions.py
             path: "geonode-k8s-settings-additions.py"
+{{- if .Values.geonode.mapstore_nominatim_patch.enabled }}
+      - name: mapstore-nominatim-patch-py
+        configMap:
+          name: "{{ include "geonode_pod_name" . }}-mapstore-nominatim-patch"
+{{- end }}
 
       # Using an emptyDir to cache compiled statics... it will survive container crashes, but not pod restarts
       - name: cache-volume

--- a/charts/geonode/templates/geonode/mapstore-patch-nominatim-url.yaml
+++ b/charts/geonode/templates/geonode/mapstore-patch-nominatim-url.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.geonode.mapstore_nominatim_patch.enabled }}
+{{- $host := required "geonode.mapstore_nominatim_patch.host is required when geonode.mapstore_nominatim_patch.enabled=true" .Values.geonode.mapstore_nominatim_patch.host }}
+{{- $protocol := required "geonode.mapstore_nominatim_patch.protocol is required when geonode.mapstore_nominatim_patch.enabled=true" .Values.geonode.mapstore_nominatim_patch.protocol }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/geonode/templates/geonode/mapstore-patch-nominatim-url.yaml
+++ b/charts/geonode/templates/geonode/mapstore-patch-nominatim-url.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.geonode.mapstore_nominatim_patch.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "geonode_pod_name" . }}-mapstore-nominatim-patch"
+  namespace: {{ .Release.Namespace }}
+data:
+  mapstore_nominatim_patch.py: |
+    import glob, shutil
+
+    # ── JS-Bundle patchen und ins PV kopieren ─────────────────────
+    nominatim_host = {{ .Values.geonode.mapstore_nominatim_patch.host | squote }}
+    nominatim_protocol = {{ .Values.geonode.mapstore_nominatim_patch.protocol | squote }}
+
+    venv_js_files = sorted(glob.glob(
+        '/usr/src/venv/lib/python*/site-packages/'
+        'geonode_mapstore_client/static/mapstore/dist/js/gn-*.js'
+    ))
+
+    if not venv_js_files:
+        print("WARNUNG: gn-*.js im venv nicht gefunden!")
+    else:
+        for venv_file in venv_js_files:
+            with open(venv_file, 'r') as f:
+                js_content = f.read()
+
+            if 'nominatim.openstreetmap.org' not in js_content:
+                continue
+
+            print("=== Mapstore: patche JS-Bundle", venv_file, "===")
+
+            js_content = js_content.replace(
+                'protocol:"https",host:"nominatim.openstreetmap.org"',
+                f'protocol:"{nominatim_protocol}",host:"{nominatim_host}"'
+            )
+            js_content = js_content.replace(
+                'protocol:"https",host:"nominatim.openstreetmap.org/reverse"',
+                f'protocol:"{nominatim_protocol}",host:"{nominatim_host}/reverse"'
+            )
+
+            import os
+            filename = os.path.basename(venv_file)
+            static_file = f'/mnt/volumes/statics/static/mapstore/dist/js/{filename}'
+            if os.path.exists(static_file):
+                with open(static_file, 'w') as f:
+                    f.write(js_content)
+                print(f"=== Mapstore: {filename} → PV kopiert (host={nominatim_host} protocol={nominatim_protocol}) ===")
+            else:
+                print(f"WARNUNG: {static_file} nicht gefunden, überspringe PV-Kopie")
+
+{{- end }}

--- a/charts/geonode/templates/geonode/mapstore-patch-nominatim-url.yaml
+++ b/charts/geonode/templates/geonode/mapstore-patch-nominatim-url.yaml
@@ -8,7 +8,7 @@ data:
   mapstore_nominatim_patch.py: |
     import glob, shutil
 
-    # ── JS-Bundle patchen und ins PV kopieren ─────────────────────
+    # Patch the JS-Bundle
     nominatim_host = {{ .Values.geonode.mapstore_nominatim_patch.host | squote }}
     nominatim_protocol = {{ .Values.geonode.mapstore_nominatim_patch.protocol | squote }}
 
@@ -18,7 +18,7 @@ data:
     ))
 
     if not venv_js_files:
-        print("WARNUNG: gn-*.js im venv nicht gefunden!")
+        print("WARNING: gn-*.js not found in venv!")
     else:
         for venv_file in venv_js_files:
             with open(venv_file, 'r') as f:
@@ -27,7 +27,7 @@ data:
             if 'nominatim.openstreetmap.org' not in js_content:
                 continue
 
-            print("=== Mapstore: patche JS-Bundle", venv_file, "===")
+            print("=== Mapstore: patching JS-Bundle", venv_file, "===")
 
             js_content = js_content.replace(
                 'protocol:"https",host:"nominatim.openstreetmap.org"',
@@ -44,8 +44,8 @@ data:
             if os.path.exists(static_file):
                 with open(static_file, 'w') as f:
                     f.write(js_content)
-                print(f"=== Mapstore: {filename} → PV kopiert (host={nominatim_host} protocol={nominatim_protocol}) ===")
+                print(f"=== Mapstore: {filename} → copied to PV (host={nominatim_host} protocol={nominatim_protocol}) ===")
             else:
-                print(f"WARNUNG: {static_file} nicht gefunden, überspringe PV-Kopie")
+                print(f"WARNING: {static_file} not found, not copying to PV")
 
 {{- end }}

--- a/charts/geonode/templates/geonode/mapstore-patch-nominatim-url.yaml
+++ b/charts/geonode/templates/geonode/mapstore-patch-nominatim-url.yaml
@@ -1,6 +1,6 @@
-{{- if .Values.geonode.mapstore_nominatim_patch.enabled }}
-{{- $host := required "geonode.mapstore_nominatim_patch.host is required when geonode.mapstore_nominatim_patch.enabled=true" .Values.geonode.mapstore_nominatim_patch.host }}
-{{- $protocol := required "geonode.mapstore_nominatim_patch.protocol is required when geonode.mapstore_nominatim_patch.enabled=true" .Values.geonode.mapstore_nominatim_patch.protocol }}
+{{- if .Values.geonode.mapstore.nominatim_patch.enabled }}
+{{- $host := required "geonode.mapstore.nominatim_patch.host is required when geonode.mapstore.nominatim_patch.enabled=true" .Values.geonode.mapstore.nominatim_patch.host }}
+{{- $protocol := required "geonode.mapstore.nominatim_patch.protocol is required when geonode.mapstore.nominatim_patch.enabled=true" .Values.geonode.mapstore.nominatim_patch.protocol }}
 
 apiVersion: v1
 kind: ConfigMap
@@ -12,8 +12,8 @@ data:
     import glob, shutil
 
     # Patch the JS-Bundle
-    nominatim_host = {{ .Values.geonode.mapstore_nominatim_patch.host | squote }}
-    nominatim_protocol = {{ .Values.geonode.mapstore_nominatim_patch.protocol | squote }}
+    nominatim_host = {{ .Values.geonode.mapstore.nominatim_patch.host | squote }}
+    nominatim_protocol = {{ .Values.geonode.mapstore.nominatim_patch.protocol | squote }}
 
     venv_js_files = sorted(glob.glob(
         '/usr/src/venv/lib/python*/site-packages/'

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -353,6 +353,12 @@ geonode:
         # -- limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
         cpu: 2
 
+  # Patch to override nominatim hard-coded url
+  mapstore_nominatim_patch:
+    enabled: false
+  #   host: "someotherhost.example.com"
+  #   protocol: "https"
+
 # CONFIGURATION FOR GEOSERVER DEPLOYMENT
 geoserver:
   # -- geoserver container name

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -353,11 +353,12 @@ geonode:
         # -- limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
         cpu: 2
 
-  # Patch to override nominatim hard-coded url
-  mapstore_nominatim_patch:
-    enabled: false
-  #   host: "someotherhost.example.com"
-  #   protocol: "https"
+  mapstore:
+    # Patch to override nominatim hard-coded url
+    nominatim_patch:
+      enabled: false
+      # host: "someotherhost.example.com"
+      # protocol: "https"
 
 # CONFIGURATION FOR GEOSERVER DEPLOYMENT
 geoserver:


### PR DESCRIPTION
## Description

Patch to allow to override the host being called for geographical searches via nominatim API. Currently, it is hardcoded to nominatim.openstreetmap.org

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

closes #303 
