### PR TITLE
[Fixes #305]: Feature: make this chart aware of Gateway API

### DIFF
--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -26,6 +26,19 @@ Helm Chart for Geonode. Supported versions: Geonode: 5.0.1, Geoserver: 2.27.4-la
 | oci://registry-1.docker.io/cloudpirates | rabbitmq | 0.2.12 |
 | oci://registry-1.docker.io/cloudpirates | redis | 0.19.0 |
 
+## Gateway API
+
+The chart can render a parallel `HTTPRoute` in addition to the existing
+Ingress. Enable it with `geonode.gatewayApi.enabled` and provide
+`geonode.gatewayApi.parentRefs` pointing at your shared Gateway listener.
+
+If `geonode.gatewayApi.hostnames` is left empty, the route defaults to
+`geonode.general.externalDomain` and mirrors the current ingress path split:
+
+- `/` -> GeoNode nginx service
+- `/geoserver` -> GeoServer service
+- `pycsw.endpoint` -> pycsw service when enabled
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/geonode/templates/nginx/nginx-httproute.yaml
+++ b/charts/geonode/templates/nginx/nginx-httproute.yaml
@@ -1,0 +1,52 @@
+{{- $gatewayApi := .Values.geonode.gatewayApi | default dict }}
+{{- $enabled := $gatewayApi.enabled | default false }}
+{{- $parentRefs := $gatewayApi.parentRefs | default (list) }}
+{{- $hostnames := $gatewayApi.hostnames | default (list) }}
+{{- $externalDomain := .Values.geonode.general.externalDomain | default "" }}
+{{- if and $enabled (eq (len $hostnames) 0) (ne $externalDomain "") }}
+  {{- $hostnames = list $externalDomain }}
+{{- end }}
+{{- if and $enabled (gt (len $parentRefs) 0) (gt (len $hostnames) 0) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: "{{ include "nginx_pod_name" . }}"
+  namespace: {{ .Release.Namespace }}
+  {{- with $gatewayApi.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $gatewayApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $parentRefs | nindent 4 }}
+  hostnames:
+    {{- toYaml $hostnames | nindent 4 }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /geoserver
+      backendRefs:
+        - name: "{{ include "geoserver_pod_name" . }}"
+          port: {{ .Values.geoserver.port }}
+    {{- if .Values.pycsw.enabled }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.pycsw.endpoint | quote }}
+      backendRefs:
+        - name: "{{ include "pycsw_pod_name" . }}"
+          port: {{ .Values.pycsw.port }}
+    {{- end }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: "{{ include "nginx_pod_name" . }}"
+          port: 80
+{{- end }}

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -103,6 +103,18 @@ geonode:
     # -- tls certificate for geonode ingress https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/ (for the use of cert-manager, configure the acme section properly). is used when geonode.general.externalScheme is set to 'https'
     tlsSecret: geonode-tls-secret
 
+  gatewayApi:
+    # -- enable a parallel Gateway API HTTPRoute for GeoNode while keeping ingress available
+    enabled: False
+    # -- labels for the Gateway API HTTPRoute
+    labels: {}
+    # -- annotations for the Gateway API HTTPRoute
+    annotations: {}
+    # -- Gateway API parentRefs, for example a shared HTTPS listener on a cluster Gateway
+    parentRefs: []
+    # -- explicit hostnames for the HTTPRoute; defaults to geonode.general.externalDomain when empty
+    hostnames: []
+
   acme:
     # -- enables cert-manager to do ACME challenges (aka certificates via letsencrypt)
     enabled: False


### PR DESCRIPTION
Adds optional Gateway API support alongside the existing Ingress.

- New `geonode.gatewayApi` values section to enable and configure an `HTTPRoute`
- Route mirrors the ingress path split: `/` -> nginx, `/geoserver` -> GeoServer, pycsw endpoint when enabled
- Hostnames default to `geonode.general.externalDomain` if left empty
- Backwards-compatible — disabled by default

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #305