### PR TITLE
[Fixes #298]: "Bug: `BING_API_KEY` value in geonode secret always unsynced

### DIFF
--- a/charts/geonode/templates/geonode/geonode-secret.yaml
+++ b/charts/geonode/templates/geonode/geonode-secret.yaml
@@ -21,5 +21,5 @@ data:
   OAUTH2_CLIENT_ID: {{ .Values.geonode.secret.oauth2.clientId | b64enc }}
   OAUTH2_CLIENT_SECRET: {{ .Values.geonode.secret.oauth2.clientSecret | b64enc }}
   SECRET_KEY: {{ .Values.geonode.secret.django.secretKey | b64enc }}
-  BING_API_KEY: {{ .Values.geonode.secret.bing.apiKey | b64enc }}
+  BING_API_KEY: {{ .Values.geonode.secret.bing.apiKey | b64enc | quote }}
 {{ end }}


### PR DESCRIPTION
## Description

Fixes unsyncable state of `BING_API_KEY` env var

## Type of Change

Please select the relevant option:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #298 

## Checklist

Please ensure that your pull request meets the following requirements:

- The pull request is limited to one type (docs, feature, bug fix, etc.)
- The pull request is as small as possible. Consider opening multiple pull requests instead of one large one.
- The feature or bug fix has been discussed and documented in an issue beforehand.

## Additional Notes

Any additional information or context regarding the pull request can be provided here.

Thank you for creating this pull request