### PR TITLE
PVC usage hardening for nginx and geoserver

### DIFF
--- a/charts/geonode/templates/geoserver/geoserver-deploy.yaml
+++ b/charts/geonode/templates/geoserver/geoserver-deploy.yaml
@@ -145,9 +145,6 @@ spec:
         volumeMounts:
         - name: pvc-geoserver-data
           mountPath: /geoserver_data/data
-        - name: pvc-statics
-          mountPath: /mnt/volumes/statics
-          readOnly: true
         - name: gs-conf
           mountPath: /usr/local/tomcat/conf
         - name: gs-home
@@ -183,9 +180,6 @@ spec:
       - name: pvc-geoserver-data
         persistentVolumeClaim:
           claimName: {{ include "pvc_geoserver_data_name" . }}
-      - name: pvc-statics
-        persistentVolumeClaim:
-          claimName: {{ include "pvc_statics_name" . }}
       - name: gs-conf
         emptyDir: {}
       - name: gs-home

--- a/charts/geonode/templates/nginx/nginx-deploy.yaml
+++ b/charts/geonode/templates/nginx/nginx-deploy.yaml
@@ -45,6 +45,7 @@ spec:
         volumeMounts:
         - name: pvc-statics
           mountPath: /mnt/volumes/statics
+          readOnly: true
         - name: nginx-confd
           mountPath: /etc/nginx/conf.d
         # Writable scratch directories for nginx


### PR DESCRIPTION
## Description

PVC usage hardening: nginx needs only read; geoserver does not need g…eonode statics pvc at all.

## Type of Change

Please select the relevant option:

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

If there is an existing issue related to this pull request, please reference it here.

closes #
