### PR TITLE
Remove celery-cmd temporary fix

### DIFF
--- a/charts/geonode/templates/geonode/celery-cmd-temporary-fix.yaml
+++ b/charts/geonode/templates/geonode/celery-cmd-temporary-fix.yaml
@@ -1,8 +1,0 @@
-# Temporary fix pending https://github.com/GeoNode/geonode/pull/14292
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-celery-cmd-temporary-fix
-data:
-  celery-cmd: |
-{{ .Files.Get "files/celery-cmd-temporary-fix" | indent 4 }}

--- a/charts/geonode/templates/geonode/geonode-deploy.yaml
+++ b/charts/geonode/templates/geonode/geonode-deploy.yaml
@@ -315,11 +315,6 @@ spec:
           mountPath: "{{ include "geonode_path" .}}/fixtures"
           readOnly: true
         {{ end }}
-        # Temporary fix pending fix in upstream Geonode https://github.com/GeoNode/geonode/pull/14292
-        - name: celery-cmd
-          mountPath: /usr/bin/celery-cmd
-          subPath: celery-cmd
-          readOnly: true
 
         resources:
           requests:
@@ -388,9 +383,4 @@ spec:
           emptyDir: {}
         - name: home-celery
           emptyDir: {}
-        # Temporary fix pending fix in upstream Geonode https://github.com/GeoNode/geonode/pull/14292
-        - name: celery-cmd
-          configMap:
-            name: {{ .Release.Name }}-celery-cmd-temporary-fix
-            defaultMode: 0555
 

--- a/docs/upgrade-to-2.0.x.md
+++ b/docs/upgrade-to-2.0.x.md
@@ -324,7 +324,7 @@ The old PVC still holds the original data. Do **not** run Step 11 until you are 
   performs Step 2 by hand. A keep annotation (or a documented migration hook) would make
   this safe by default.
 - **`settings_additions` inert by default** — see Step 8.
-- **Celery `celery-cmd-temporary-fix` keeps heavy autoscale defaults** (`10,5` + `15,10`),
+- **Celery `celery-cmd` keeps heavy autoscale defaults** (`10,5` + `15,10`),
   which can OOMKill the celery container on uploads unless `CELERY__AUTOSCALE_VALUES` /
   `CELERY__HARVESTER_AUTOSCALE_VALUES` are lowered.
 


### PR DESCRIPTION
## Description

Remove celery-cmd temporary fix: the upstream fix was published with Geonode 5.1.0

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Refactoring
- [ ] Other (please describe)

## Related Issue

closes #310 