### PR TITLE
Colocation option for geonode pods that use common PVCs

### DIFF
--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -43,6 +43,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 5.1.0, Geoserver: 2.28.4-la
 | geonode.celery.resources.limits.memory | string | `"2Gi"` | limits memory as in resource.limits.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | geonode.celery.resources.requests.cpu | int | `1` | requested cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
 | geonode.celery.resources.requests.memory | string | `"1Gi"` | requested memory as in resource.requests.memory (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) |
+| geonode.colocation.enabled | bool | `false` | set colocation for geonode pods that use common PVCs (needed if using RWO storage) |
 | geonode.container_name | string | `"geonode"` |  |
 | geonode.gatewayApi.annotations | object | `{}` | annotations for the Gateway API HTTPRoute |
 | geonode.gatewayApi.enabled | bool | `false` | enable a parallel Gateway API HTTPRoute for GeoNode while keeping ingress available |

--- a/charts/geonode/templates/_helpers.tpl
+++ b/charts/geonode/templates/_helpers.tpl
@@ -196,3 +196,18 @@ geonode/base/fixtures/initial_data.json
 initial_data.json
 {{- end -}}
 {{- end -}}
+
+# Hard co-location affinity for workloads sharing RWO block-storage PVCs
+# (statics, geoserver-data, data). Anchors all consumers to the node of the
+# geonode pod, since RWO volumes can only be mounted on a single node.
+{{- define "geonode.colocation_affinity" -}}
+{{- if .Values.geonode.colocation.enabled }}
+affinity:
+  podAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchLabels:
+          org.geonode.instance: "{{ include "geonode_pod_name" . }}"
+      topologyKey: kubernetes.io/hostname
+{{- end }}
+{{- end -}}

--- a/charts/geonode/templates/geonode/jobs/geonode-init-db-job.yaml
+++ b/charts/geonode/templates/geonode/jobs/geonode-init-db-job.yaml
@@ -21,6 +21,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.geonode.imagePullSecret }}
 {{ end }}
+      {{- include "geonode.colocation_affinity" . | nindent 6 }}
       restartPolicy: OnFailure
 {{- $gnctx := default dict .Values.geonode.securityContext }}
       securityContext:

--- a/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
+++ b/charts/geonode/templates/geonode/jobs/geonode-statics-job.yaml
@@ -21,6 +21,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.geonode.imagePullSecret }}
 {{ end }}
+      {{- include "geonode.colocation_affinity" . | nindent 6 }}
       restartPolicy: OnFailure
 {{- $gnctx := default dict .Values.geonode.securityContext }}
       securityContext:

--- a/charts/geonode/templates/geoserver/geoserver-deploy.yaml
+++ b/charts/geonode/templates/geoserver/geoserver-deploy.yaml
@@ -19,6 +19,7 @@ spec:
         checksum/geoserver-secret: {{ include (print $.Template.BasePath "/geoserver/geoserver-secret.yaml") . | sha256sum }}
 
     spec:
+      {{- include "geonode.colocation_affinity" . | nindent 6 }}
       {{- $gsctx := default dict .Values.geoserver.securityContext }}
       securityContext:
         runAsNonRoot: {{- if hasKey $gsctx "runAsNonRoot" }} {{ $gsctx.runAsNonRoot }} {{- else }} true {{- end }}

--- a/charts/geonode/templates/nginx/nginx-deploy.yaml
+++ b/charts/geonode/templates/nginx/nginx-deploy.yaml
@@ -15,6 +15,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/nginx/nginx-conf.yaml") . | sha256sum }}
     spec:
+      {{- include "geonode.colocation_affinity" . | nindent 6 }}
       terminationGracePeriodSeconds: 3
 {{- if not (empty .Values.nginx.imagePullSecret) }}
       imagePullSecrets:

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -24,7 +24,6 @@ geonode:
   replicaCount: 1
   # -- Security context for geonode pods (overrides global.securityContext)
   securityContext: {}
-
   persistant:
     # -- size of statics storage
     statics:
@@ -440,6 +439,12 @@ geonode:
         memory: "2Gi"
         # -- limit cpu as in resource.requests.cpu (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
         cpu: 2
+
+  colocation:
+    # -- Schedule all workloads that share PVCs (geoserver, nginx, statics-
+    # -- and init-db-job) onto the same node as the geonode pod. Required
+    # -- when using ReadWriteOnce block storage on multi-node clusters.
+    enabled: false
 
   mapstore:
     # Patch to override nominatim hard-coded url


### PR DESCRIPTION
## Description

Provide optional colocation for geonode pods using common PVCs, to support RWO environments.

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

closes #325 


## Additional Notes

This has been tested with OpenEBS block storage and with Nutanix storage.