### PR TITLE
Add logic to read custom fixture files

### DIFF
--- a/charts/geonode/templates/geonode/geonode-tasks-py-conf.yaml
+++ b/charts/geonode/templates/geonode/geonode-tasks-py-conf.yaml
@@ -363,6 +363,13 @@ data:
     --settings={_localsettings()}",
             pty=True,
         )
+        {{- range $key, $value := .Values.geonodeFixtures }}
+        ctx.run(
+            f"python manage.py loaddata {{ include "geonode_path" $ }}/fixtures/{{ $key }} \
+    --settings={_localsettings()}",
+            pty=True,
+        )
+        {{- end }}
 
     @task
     def collectstatic(ctx):

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -1009,7 +1009,7 @@ postgres-operator:
     spilo_fsgroup: 103
     spilo_privileged: false
     spilo_allow_privilege_escalation: false
-# -- (map of fixture files) Fixture files which shall be made available under /usr/src/geonode/geonode/fixtures (refer to https://docs.djangoproject.com/en/4.2/howto/initial-data/)
+# -- (map of fixture files) Fixture files which are made available under /usr/src/geonode/geonode/fixtures and loaded into the database via `manage.py loaddata` during the init-db job (refer to https://docs.djangoproject.com/en/4.2/howto/initial-data/)
 geonodeFixtures:
   # @gignore
 #  somefixture.json: |


### PR DESCRIPTION
## Description

Currently, custom fixtures can be defined, but they are not loaded automatically (they can be loaded manually within the pod, but as a site administrator, I expect that they are loaded automatically). This pull request addresses that.

## Type of Change

Please select the relevant option:

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue
closes #328 

## Additional Notes

Because, as per time of creation of this pull request, geonode Pod will start as ready before the init DB job completes, custom fixture settings will not be consistently available due to caching issues during the first 10 minutes of operation. This is because at start, the fixtures are not loaded yet. However, each worker's cache validity is 10 minutes, at which point the updated settings will be read, so after 10 minutes the loaded settings will be consistently available in each worker. Changing this behavior is not strictly related to this issue, and should therefore be addressed in a separate issue.