### PR TITLE
Geonode Readiness: wait for init db data migrations

### DIFF
--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -154,6 +154,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 5.1.0, Geoserver: 2.28.4-la
 | geonode.uwsgi.threads | int | `24` | number of threads per process |
 | geonode.uwsgi.worker_reload_mercy | int | `60` | How long to wait before forcefully killing workers |
 | geonode.version | string | `"5.1.0"` | GeoNode version used for chart-side version gating (env var names, defaults). Must be kept in sync with `geonode.image.tag`. Non-semver values (e.g. "latest", sha digest pins) fall back to newest-version behavior. |
+| geonode.waitForInitDb | bool | `true` | On geonode startup, wait until the init-db job has initialized the database, so the pod only becomes Ready once the DB is usable |
 | geonodeFixtures | map of fixture files | `nil` | Fixture files which shall be made available under /usr/src/geonode/geonode/fixtures (refer to https://docs.djangoproject.com/en/4.2/howto/initial-data/) |
 | geoserver.container_name | string | `"geoserver"` | geoserver container name |
 | geoserver.force_reinit | bool | `true` | set force reinit true so that changing passwords etc. in Values.yaml will take effect after restarting the pod this on the other hand will increase pod initializing time, only change if you know what you are doing |

--- a/charts/geonode/templates/geonode/geonode-deploy.yaml
+++ b/charts/geonode/templates/geonode/geonode-deploy.yaml
@@ -97,6 +97,77 @@ spec:
             mountPath: /seed-geonode
           - name: home-celery
             mountPath: /seed-celery
+      {{- if .Values.geonode.waitForInitDb.enabled }}
+      # Block the app containers until the init-db job has applied all
+      # database migrations, so the pod only becomes Ready once the
+      # database is initialized and usable.
+      - name: wait-for-init-db
+        image: "{{ .Values.geonode.image.name }}:{{ .Values.geonode.image.tag }}"
+        imagePullPolicy: {{ .Values.geonode.imagePullPolicy }}
+        securityContext:
+          runAsUser: {{- if hasKey $gnctx "runAsUser" }} {{ $gnctx.runAsUser }} {{- else }} {{ .Values.global.securityContext.runAsUser }} {{- end }}
+          runAsGroup: {{- if hasKey $gnctx "runAsGroup" }} {{ $gnctx.runAsGroup }} {{- else }} {{ .Values.global.securityContext.runAsGroup }} {{- end }}
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        command:
+        - bash
+        - -c
+        - |
+          echo "wait-for-init-db: waiting for database migrations to be applied..."
+          until python manage.py migrate --check >/dev/null 2>&1; do
+            echo "wait-for-init-db: migrations still pending, retrying in 10s..."
+            sleep 10
+          done
+          echo "wait-for-init-db: all migrations applied, continuing startup"
+        envFrom:
+        - configMapRef:
+            name: {{ include "geonode_pod_name" . }}-env
+        - secretRef:
+            name: {{ .Values.geonode.secret.existingSecretName | default (include "geonode_secret_name" .) | quote }}
+        - secretRef:
+            name: {{ .Values.geoserver.secret.existingSecretName | default (include "geoserver_secret_name" .) | quote }}
+        env:
+        - name: GEONODE_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "database_geonode_password_secret_key_ref" . }}
+              key: {{ include "database_geonode_password_key_ref" . }}
+        - name: GEONODE_GEODATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "database_geodata_password_secret_key_ref" . }}
+              key: {{ include "database_geodata_password_key_ref" . }}
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "database_postgres_password_secret_key_ref" . }}
+              key: {{ include "database_postgres_password_key_ref" . }}
+        - name: GEODATABASE_URL
+          value: "postgis://$(GEONODE_GEODATABASE):$(GEONODE_GEODATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(GEONODE_GEODATABASE)"
+        - name: DATABASE_URL
+          value: "postgis://$(GEONODE_DATABASE):$(GEONODE_DATABASE_PASSWORD)@$(DATABASE_HOST):$(DATABASE_PORT)/$(GEONODE_DATABASE)"
+        - name: PYTHONPATH
+          value: "/opt/geonode-custom"
+        volumeMounts:
+        - name: cache-volume
+          mountPath: /tmp
+        - name: home-geonode
+          mountPath: /home/ubuntu
+        - name: settings-wrapper
+          mountPath: /opt/geonode-custom/settings_wrapper.py
+          subPath: settings_wrapper.py
+          readOnly: true
+        - name: settings-additions
+          mountPath: /opt/geonode-custom/settings_additions.py
+          subPath: settings_additions.py
+          readOnly: true
+      {{- end }}
 
       containers:
       # This is the django app server

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -50,6 +50,10 @@ geonode:
   # -- pull secret to use for geonode image
   imagePullSecret: ""
 
+  waitForInitDb:
+    # -- (bool) Block the geonode/celery containers with an init container until all Django migrations are applied (i.e. the init-db job has initialized the database), so the pod only becomes Ready once the DB is usable
+    enabled: true
+
   # -- additions to tasks.py init script, must be additional code written in python
   tasks_pre_script: |
     print("tasks_pre_script not defined ...")


### PR DESCRIPTION
## Description

Currently the geonode pod's init containers only wait for the database/redis TCP endpoints, not for the database content initialisation. As a result the pod can become Ready and serve the UI while data migrations are still being applied, so users reach a UI backed by an uninitialized database. This is misleading for the user, because it looks like the application is ready, but in fact it is not and the user can get strange errors when trying to use the application at this stage.

With this pull request, geonode readiness will take into account the completion of the data migration.

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

closes #330 