### PR TITLE
Repair raster upload: geoserver needs access (read-only) to statics volume, where Geonode places uploaded raster files

### DIFF
--- a/charts/geonode/templates/geoserver/geoserver-deploy.yaml
+++ b/charts/geonode/templates/geoserver/geoserver-deploy.yaml
@@ -146,6 +146,9 @@ spec:
         volumeMounts:
         - name: pvc-geoserver-data
           mountPath: /geoserver_data/data
+        - name: pvc-statics
+          mountPath: /mnt/volumes/statics
+          readOnly: true
         - name: gs-conf
           mountPath: /usr/local/tomcat/conf
         - name: gs-home
@@ -181,6 +184,9 @@ spec:
       - name: pvc-geoserver-data
         persistentVolumeClaim:
           claimName: {{ include "pvc_geoserver_data_name" . }}
+      - name: pvc-statics
+        persistentVolumeClaim:
+          claimName: {{ include "pvc_statics_name" . }}
       - name: gs-conf
         emptyDir: {}
       - name: gs-home


### PR DESCRIPTION
## Description

The PR #323 was too aggressive and introduced a bug:

The upload of raster files is different from the upload of vector data. For raster file, geoserver needs access (read-only) to statics volume, because Geonode places uploaded raster files there.

## Type of Change

Please select the relevant option:

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)
