### PR TITLE
Add optional tolerations configuration, to be able to override K8S defaults

### DIFF
--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -194,6 +194,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 5.1.0, Geoserver: 2.28.4-la
 | global.securityContext.runAsGroup | int | `1000` | Group ID to run the containers |
 | global.securityContext.runAsUser | int | `1000` | User ID to run the containers |
 | global.storageClass | string | `nil` | storageClass used by helm dependencies pvc |
+| global.tolerations | list | empty list | option to overwrite K8S default tolerations, to survive long-lasting node reboots |
 | memcached.config.maxConnections | int | `2048` |  |
 | memcached.config.memoryLimit | int | `128` |  |
 | memcached.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |

--- a/charts/geonode/templates/_helpers.tpl
+++ b/charts/geonode/templates/_helpers.tpl
@@ -211,3 +211,11 @@ affinity:
       topologyKey: kubernetes.io/hostname
 {{- end }}
 {{- end -}}
+
+# Tolerations for workload pods. Renders a tolerations block; emits nothing when the list is empty.
+{{- define "geonode.tolerations" -}}
+{{- with .Values.global.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/geonode/templates/geonode/geonode-deploy.yaml
+++ b/charts/geonode/templates/geonode/geonode-deploy.yaml
@@ -40,6 +40,7 @@ spec:
         fsGroup: {{- if hasKey $gnctx "fsGroup" }} {{ $gnctx.fsGroup }} {{- else }} {{ .Values.global.securityContext.fsGroup }} {{- end }}
         fsGroupChangePolicy: OnRootMismatch
       terminationGracePeriodSeconds: 3
+      {{- include "geonode.tolerations" . | nindent 6 }}
 {{- if not (empty .Values.geonode.imagePullSecret) }}
       imagePullSecrets:
       - name: {{ .Values.geonode.imagePullSecret }}

--- a/charts/geonode/templates/geoserver/geoserver-deploy.yaml
+++ b/charts/geonode/templates/geoserver/geoserver-deploy.yaml
@@ -20,6 +20,7 @@ spec:
 
     spec:
       {{- include "geonode.colocation_affinity" . | nindent 6 }}
+      {{- include "geonode.tolerations" . | nindent 6 }}
       {{- $gsctx := default dict .Values.geoserver.securityContext }}
       securityContext:
         runAsNonRoot: {{- if hasKey $gsctx "runAsNonRoot" }} {{ $gsctx.runAsNonRoot }} {{- else }} true {{- end }}

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -12,6 +12,10 @@ global:
     runAsGroup: 1000
     # -- Group ID for volume mounts
     fsGroup: 1000
+  # -- Tolerations option, so K8S default can be overwritten. Useful for long-running pods
+  # (geonode, geoserver) which should survive node reboots.
+  # Empty list keeps the cluster default (300 seconds).
+  tolerations: []
 
 # geonode configuration
 geonode:


### PR DESCRIPTION
## Description

Add optional tolerations configuration, to be able to override K8S default tolerations. 

One example use case is: a worker node is temporarily unavailable, for example due to a reboot. For pods with affinity, K8S (master node) will attempt to restart the pods on that worker node during 300 seconds; if the node does not become Ready within that time, the pods will not get restarted and manual intervention by operations becomes necessary. Environments where worker node unavailability for longer than 300 seconds can occur need to overwrite this default.

Example configuration that can be used after this change:
```
global:
  tolerations:
    - key: node.kubernetes.io/unreachable
      operator: Exists
      effect: NoExecute
      tolerationSeconds: 1800
    - key: node.kubernetes.io/not-ready
      operator: Exists
      effect: NoExecute
      tolerationSeconds: 1800
````

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)
