### PR TITLE
Add Pvc retain policy

### DIFF
--- a/charts/geonode/README.md
+++ b/charts/geonode/README.md
@@ -189,6 +189,7 @@ Helm Chart for Geonode. Supported versions: Geonode: 5.1.0, Geoserver: 2.28.4-la
 | geoserver_data.image.tag | string | `"2.28.4-latest"` | geoserver docker image tag |
 | geoserver_data.imagePullPolicy | string | `"IfNotPresent"` | geoserver image pull policy |
 | global.accessMode | string | `"ReadWriteMany"` | storage access mode used by helm dependency pvc |
+| global.persistence.retainOnUninstall | bool | `true` | Keep the data PVCs on `helm uninstall` |
 | global.securityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsUser":1000}` | Global security context defaults for all pods Can be overridden per component via component.securityContext.runAsUser etc. |
 | global.securityContext.fsGroup | int | `1000` | Group ID for volume mounts |
 | global.securityContext.runAsGroup | int | `1000` | Group ID to run the containers |

--- a/charts/geonode/templates/geonode/geonode-pvc.yaml
+++ b/charts/geonode/templates/geonode/geonode-pvc.yaml
@@ -3,6 +3,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-{{ .Release.Name }}-geonode-statics
   namespace: {{ .Release.Namespace }}
+  {{- if (default dict .Values.global.persistence).retainOnUninstall }}
+  annotations:
+    # Keep this PVC on `helm uninstall` so data stays in sync with the (surviving) database.
+    helm.sh/resource-policy: keep
+  {{- end }}
 spec:
   accessModes:
   - {{ .Values.global.accessMode }}
@@ -18,6 +23,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-{{ .Release.Name }}-geonode-geoserver-data
   namespace: {{ .Release.Namespace }}
+  {{- if (default dict .Values.global.persistence).retainOnUninstall }}
+  annotations:
+    # Keep this PVC on `helm uninstall` so data stays in sync with the (surviving) database.
+    helm.sh/resource-policy: keep
+  {{- end }}
 spec:
   accessModes:
   - {{ .Values.global.accessMode }}
@@ -48,6 +58,11 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-{{ .Release.Name }}-geonode-data
   namespace: {{ .Release.Namespace }}
+  {{- if (default dict .Values.global.persistence).retainOnUninstall }}
+  annotations:
+    # Keep this PVC on `helm uninstall` so data stays in sync with the (surviving) database.
+    helm.sh/resource-policy: keep
+  {{- end }}
 spec:
   accessModes:
   - {{ .Values.global.accessMode }}

--- a/charts/geonode/values.yaml
+++ b/charts/geonode/values.yaml
@@ -3,6 +3,9 @@ global:
   storageClass:
   # -- storage access mode used by helm dependency pvc
   accessMode: ReadWriteMany
+  persistence:
+    # -- Keep the data PVCs (statics, geoserver_data, geonode_data) on `helm uninstall` …
+    retainOnUninstall: true
   # -- Global security context defaults for all pods
   # Can be overridden per component via component.securityContext.runAsUser etc.
   securityContext:


### PR DESCRIPTION
## Description

Add global.persistence.retainOnUninstall. When enabled, the statics, geoserver_data and geonode_data PVCs get the
helm.sh/resource-policy: keep annotation so they survive helm uninstall.
 
This keeps the file storage in sync with an operator-managed database that also survives uninstall: otherwise, after uninstall+reinstall the DB still references resources whose raster files and GeoServer catalog were deleted, leaving GeoNode in an inconsistent state (thumbnails present, layers show only the base map). The transient backup-restore PVC is left deletable.
 
Default is set to true; but can be overwritten in project YAML file to keep the old behavior (automatically delete PVC on uninstall).

## Type of Change

Please select the relevant option:

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)


Thank you for creating this pull request